### PR TITLE
missing related fuzz testing tags, findability tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,16 @@
     "test",
     "testing",
     "property-based",
-    "quickcheck"
+    "property",
+    "quickcheck",
+    "stochastic",
+    "fuzz",
+    "fuzzer",
+    "proper",
+    "triq",
+    "stoch",
+    "afl",
+    "checkers"
   ],
   "author": "Glen Mailer <glen@stainlessed.co.uk>",
   "license": "EPL",


### PR DESCRIPTION
in light of riding qc's name, also ride proper, triq, american fuzzy lop

with property-based, add property, fuzz, fuzzer, stochastic, stoch

recommend adding lib's own name as tag so that libraries of support generators can use the same tag to be findable on npm
