### PR TITLE
extraneous `it()` wrapper in mocha test wrapper breaks mocha tests

### DIFF
--- a/mocha.js
+++ b/mocha.js
@@ -25,7 +25,5 @@ function checking(desc, args, body, n, options) {
         options = n;
         n = 1000;
     }
-    it(desc, function() {
-        checkers.forAll(args, body).check(n, options);
-    });
+    return checkers.forAll(args, body).check(n, options);
 }


### PR DESCRIPTION
In your `mocha` wrapper, the interior of the function isn't actually executed from within an `it/2` wrapper given [your example code](https://github.com/glenjamin/checkers#usage-with-mocha). Stripping off the `it/2` wrapper inside, and allowing the outside `it/2` to drive the bus, seems to work as expected.

See [saucy explanation](https://github.com/glenjamin/checkers/issues/5).
